### PR TITLE
handle numeric ids

### DIFF
--- a/lib/weightGenerator.js
+++ b/lib/weightGenerator.js
@@ -26,10 +26,12 @@ function generator( record ){
 
     // poi-address and addresses
     if( type === 'osmnode' || type === 'osmway' ){
-      if( record.id.match('poi-address') ){
-        type = 'poi-address';
-      } else if( record.id.match('address') ){
-        type = 'address';
+      if( 'string' === typeof record.id ){
+        if( record.id.match('poi-address') ){
+          type = 'poi-address';
+        } else if( record.id.match('address') ){
+          type = 'address';
+        }
       }
     }
 

--- a/test/lib/weightGenerator.js
+++ b/test/lib/weightGenerator.js
@@ -68,6 +68,16 @@ module.exports.tests.poi_address = function(test, common) {
   });
 };
 
+// some pipelines may return numeric ids
+module.exports.tests.numeric_id = function(test, common) {
+  var record = { _meta: { type: 'osmnode' }, id: 1 };
+  test('numeric id', function(t) {
+    var weight = weightGenerator( record );
+    t.equal(weight, 6, 'correct weight');
+    t.end();
+  });
+};
+
 module.exports.tests.locality = function(test, common) {
   var record = { _meta: { type: 'locality' } };
   test('locality type', function(t) {


### PR DESCRIPTION
bugfix for:

``` bash
TypeError: Object 670761 has no method 'match'
```
