### PR TITLE
using the weights defined in pelias-model (DRY)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 var generators = require('./lib/generators');
 var suggester = require('./lib/suggester');
+var weights   = require('./lib/weights');
 
 var suggester = {
   streams: {
     suggester: suggester
   },
   generators: generators,
-  pipeline: suggester( generators )
+  pipeline: suggester( generators ),
+  weights: weights
 };
 
 module.exports = suggester;

--- a/lib/weightGenerator.js
+++ b/lib/weightGenerator.js
@@ -14,7 +14,12 @@ function generator( record ){
     }
   }
 
-  return ( type in weights ) ? weights[ type ] : 0;
+  // use population for weighting (experimental)
+  // only weigh areas with 'large' population higher 
+  var large = 10000; 
+  var pop_weight = record.population ? (Math.ceil(record.population/large)) : 0;
+
+  return pop_weight + (( type in weights ) ? weights[ type ] : 0);
 }
 
 module.exports = generator;

--- a/lib/weightGenerator.js
+++ b/lib/weightGenerator.js
@@ -1,4 +1,4 @@
-var weights = require('pelias-model').weights;
+var weights = require('./weights');
 
 function generator( record ){
   var type = record._meta.type;

--- a/lib/weightGenerator.js
+++ b/lib/weightGenerator.js
@@ -1,16 +1,4 @@
-var weights = {
-  'geoname': 0,
-  'address': 4, // OSM addresses without a matching POI
-  'osmnode': 6,
-  'osmway': 6,
-  'poi-address': 8, // OSM addresses with a matching POI
-  'neighborhood': 10,
-  'local_admin': 12,
-  'locality': 12,
-  'admin2': 12,
-  'admin1': 14,
-  'admin0': 2
-};
+var weights = require('pelias-model').weights;
 
 function generator( record ){
   var type = record._meta.type;

--- a/lib/weightGenerator.js
+++ b/lib/weightGenerator.js
@@ -16,7 +16,7 @@ function generator( record ){
 
   // use population for weighting (experimental)
   // only weigh areas with 'large' population higher 
-  var large = 10000; 
+  var large = 1000; 
   var pop_weight = record.population ? (Math.ceil(record.population/large)) : 0;
 
   return pop_weight + (( type in weights ) ? weights[ type ] : 0);

--- a/lib/weights.js
+++ b/lib/weights.js
@@ -1,0 +1,13 @@
+module.exports = {
+  'geoname': 0,
+  'address': 4, // OSM addresses without a matching POI
+  'osmnode': 6,
+  'osmway': 6,
+  'poi-address': 8, // OSM addresses with a matching POI
+  'neighborhood': 10,
+  'local_admin': 12,
+  'locality': 12,
+  'admin2': 12,
+  'admin1': 14,
+  'admin0': 2
+};

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "npm": ">=1.4.3"
   },
   "dependencies": {
-    "through2": "^0.5.1",
-    "pelias-model": "git://github.com/pelias/model#multiplier"
+    "through2": "^0.5.1"
   },
   "devDependencies": {
     "tape": "^2.13.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "npm": ">=1.4.3"
   },
   "dependencies": {
-    "through2": "^0.5.1"
+    "through2": "^0.5.1",
+    "pelias-model": "git://github.com/pelias/model#multiplier"
   },
   "devDependencies": {
     "tape": "^2.13.4",

--- a/test/lib/weightGenerator.js
+++ b/test/lib/weightGenerator.js
@@ -37,12 +37,12 @@ tests[ 'assigns expected weights to different types and population' ] = function
   var testCases = {
     default: [{ _meta: {} }, 0],
     geoname:  [{ _meta: { type: 'geoname' }, population: 0 }, 0],
-    geoname1: [{ _meta: { type: 'geoname' }, population: 10000 }, 1],
-    geoname2: [{ _meta: { type: 'geoname' }, population: 14000 }, 2],
-    geoname3: [{ _meta: { type: 'geoname' }, population: 30000 }, 3],
+    geoname1: [{ _meta: { type: 'geoname' }, population: 10000 }, 10],
+    geoname2: [{ _meta: { type: 'geoname' }, population: 14000 }, 14],
+    geoname3: [{ _meta: { type: 'geoname' }, population: 30000 }, 30],
     geoname4: [{ _meta: { type: 'geoname' }, population: 100 }, 1],
     geoname5: [{ _meta: { type: 'geoname' }, population: 1 }, 1],
-    geoname6: [{ _meta: { type: 'geoname' }, population: 234000 }, 24],
+    geoname6: [{ _meta: { type: 'geoname' }, population: 234000 }, 234],
     geoname7: [{ _meta: { type: 'geoname' }, population: -1 }, 0],
     geoname8: [{ _meta: { type: 'geoname' }, population: NaN }, 0],
     admin0: [{ _meta: { type: 'admin0' } }, 2],
@@ -53,7 +53,7 @@ tests[ 'assigns expected weights to different types and population' ] = function
     locality: [{ _meta: { type: 'locality' } }, 12]
   };
 
-  var large_population = 10000;
+  var large_population = 1000;
 
   t.plan( Object.keys( testCases ).length );
   for( var key in testCases ){

--- a/test/lib/weightGenerator.js
+++ b/test/lib/weightGenerator.js
@@ -33,4 +33,35 @@ tests[ 'assigns expected weights to different types' ] = function ( t ){
   }
 };
 
+tests[ 'assigns expected weights to different types and population' ] = function ( t ){
+  var testCases = {
+    default: [{ _meta: {} }, 0],
+    geoname:  [{ _meta: { type: 'geoname' }, population: 0 }, 0],
+    geoname1: [{ _meta: { type: 'geoname' }, population: 10000 }, 1],
+    geoname2: [{ _meta: { type: 'geoname' }, population: 14000 }, 2],
+    geoname3: [{ _meta: { type: 'geoname' }, population: 30000 }, 3],
+    geoname4: [{ _meta: { type: 'geoname' }, population: 100 }, 1],
+    geoname5: [{ _meta: { type: 'geoname' }, population: 1 }, 1],
+    geoname6: [{ _meta: { type: 'geoname' }, population: 234000 }, 24],
+    geoname7: [{ _meta: { type: 'geoname' }, population: -1 }, 0],
+    geoname8: [{ _meta: { type: 'geoname' }, population: NaN }, 0],
+    admin0: [{ _meta: { type: 'admin0' } }, 2],
+    admin1: [{ _meta: { type: 'admin1' } }, 14],
+    admin2: [{ _meta: { type: 'admin2' } }, 12],
+    osmway: [{ _meta: { type: 'osmway' }, id: 'something-poi-address' }, 8],
+    osmnode: [{ _meta: { type: 'osmnode' }, id: 1, population: 0 }, 6],
+    locality: [{ _meta: { type: 'locality' } }, 12]
+  };
+
+  var large_population = 10000;
+
+  t.plan( Object.keys( testCases ).length );
+  for( var key in testCases ){
+    var testCase = testCases[ key ];
+    var actual = weightGenerator( testCase[ 0 ] );
+    var expected = testCase[ 1 ];
+    t.equal( actual, expected, key + ': weight matches expected.' );
+  }
+};
+
 module.exports = tests;


### PR DESCRIPTION
- Moves all the dataset (type) weights into its own module for reusability (https://github.com/pelias/api/pull/67) uses the weights as a sorting mechanism
- Uses population field as a boosting value
