### PR TITLE
Better weights

### DIFF
--- a/lib/weightGenerator.js
+++ b/lib/weightGenerator.js
@@ -15,9 +15,7 @@ function generator( record ){
   }
 
   // use population for weighting (experimental)
-  // only weigh areas with 'large' population higher 
-  var large = 1000; 
-  var pop_weight = record.population ? (Math.ceil(record.population/large)) : 0;
+  var pop_weight = record.population ? (Math.log(record.population + 1)) : 0;
 
   return pop_weight + (( type in weights ) ? weights[ type ] : 0);
 }

--- a/test/lib/weightGenerator.js
+++ b/test/lib/weightGenerator.js
@@ -34,17 +34,20 @@ tests[ 'assigns expected weights to different types' ] = function ( t ){
 };
 
 tests[ 'assigns expected weights to different types and population' ] = function ( t ){
+  var expected_result = function(pop) {
+    return pop ? Math.log(pop + 1) : 0;
+  };
   var testCases = {
     default: [{ _meta: {} }, 0],
     geoname:  [{ _meta: { type: 'geoname' }, population: 0 }, 0],
-    geoname1: [{ _meta: { type: 'geoname' }, population: 10000 }, 10],
-    geoname2: [{ _meta: { type: 'geoname' }, population: 14000 }, 14],
-    geoname3: [{ _meta: { type: 'geoname' }, population: 30000 }, 30],
-    geoname4: [{ _meta: { type: 'geoname' }, population: 100 }, 1],
-    geoname5: [{ _meta: { type: 'geoname' }, population: 1 }, 1],
-    geoname6: [{ _meta: { type: 'geoname' }, population: 234000 }, 234],
-    geoname7: [{ _meta: { type: 'geoname' }, population: -1 }, 0],
-    geoname8: [{ _meta: { type: 'geoname' }, population: NaN }, 0],
+    geoname1: [{ _meta: { type: 'geoname' }, population: 10000 }, expected_result(10000)],
+    geoname2: [{ _meta: { type: 'geoname' }, population: 14000 }, expected_result(14000)],
+    geoname3: [{ _meta: { type: 'geoname' }, population: 30000 }, expected_result(30000)],
+    geoname4: [{ _meta: { type: 'geoname' }, population: 100 }, expected_result(100)],
+    geoname5: [{ _meta: { type: 'geoname' }, population: 1 }, expected_result(1)],
+    geoname6: [{ _meta: { type: 'geoname' }, population: 234000 }, expected_result(234000)],
+    geoname7: [{ _meta: { type: 'geoname' }, population: -1 }, expected_result(-1)],
+    geoname8: [{ _meta: { type: 'geoname' }, population: NaN }, expected_result(NaN)],
     admin0: [{ _meta: { type: 'admin0' } }, 2],
     admin1: [{ _meta: { type: 'admin1' } }, 14],
     admin2: [{ _meta: { type: 'admin2' } }, 12],
@@ -52,8 +55,6 @@ tests[ 'assigns expected weights to different types and population' ] = function
     osmnode: [{ _meta: { type: 'osmnode' }, id: 1, population: 0 }, 6],
     locality: [{ _meta: { type: 'locality' } }, 12]
   };
-
-  var large_population = 1000;
 
   t.plan( Object.keys( testCases ).length );
   for( var key in testCases ){


### PR DESCRIPTION
Making sure our weights are not an incredibly large number. By using `population` directly as a weight we could encounter `integer number too large` errors. To avoid this, we were using a constant `large` - which, is not a very clean way of doing things. 

Hence, using `log` we accomplish a smooth logarithmic curve for our weights and a nice low number thus ensuring we'll never run into the error stated above. 
